### PR TITLE
fix error: call of overloaded ‘abs(unsigned int)’ is ambiguous

### DIFF
--- a/random.cpp
+++ b/random.cpp
@@ -101,8 +101,8 @@ void srand(int a, int b, int c)
 
 int rand()
 {
-
-	return abs(xsrand.rand());
+	unsigned int rand = xsrand.rand();
+	return rand;
 }
 
 /**


### PR DESCRIPTION
Fixed below error when using stdlib since c++11 

```
[*] Compiling random.cpp
random.cpp: In function ‘int rand()’:
random.cpp:104:29: error: call of overloaded ‘abs(unsigned int)’ is ambiguous
  104 |         unsigned int x = abs(xsrand.rand());
      |                          ~~~^~~~~~~~~~~~~~~
In file included from /usr/include/c++/12/stdlib.h:30,
                 from prots.h:14,
                 from random.cpp:21:
/usr/include/stdlib.h:861:12: note: candidate: ‘int abs(int)’
  861 | extern int abs (int __x) __THROW __attribute__ ((__const__)) __wur;
      |            ^~~
In file included from /usr/include/c++/12/cmath:47,
                 from /usr/include/c++/12/math.h:36,
                 from prots.h:44:
/usr/include/c++/12/bits/std_abs.h:103:3: note: candidate: ‘constexpr __float128 std::abs(__float128)’
  103 |   abs(__float128 __x)
      |   ^~~
/usr/include/c++/12/bits/std_abs.h:85:3: note: candidate: ‘constexpr __int128 std::abs(__int128)’
   85 |   abs(__GLIBCXX_TYPE_INT_N_0 __x) { return __x >= 0 ? __x : -__x; }
      |   ^~~
/usr/include/c++/12/bits/std_abs.h:79:3: note: candidate: ‘constexpr long double std::abs(long double)’
   79 |   abs(long double __x)
      |   ^~~
/usr/include/c++/12/bits/std_abs.h:75:3: note: candidate: ‘constexpr float std::abs(float)’
   75 |   abs(float __x)
      |   ^~~
/usr/include/c++/12/bits/std_abs.h:71:3: note: candidate: ‘constexpr double std::abs(double)’
   71 |   abs(double __x)
      |   ^~~
/usr/include/c++/12/bits/std_abs.h:61:3: note: candidate: ‘long long int std::abs(long long int)’
   61 |   abs(long long __x) { return __builtin_llabs (__x); }
      |   ^~~
/usr/include/c++/12/bits/std_abs.h:56:3: note: candidate: ‘long int std::abs(long int)’
   56 |   abs(long __i) { return __builtin_labs(__i); }
      |   ^~~
In file included from prots.h:101:
ptrlist.h: In instantiation of ‘ptrlist<T>::~ptrlist() [with T = ent]’:
class-ent.h:265:34:   required from here
ptrlist.h:309:41: warning: deleting object of abstract class type ‘ent’ which has non-virtual destructor will cause undefined behavior [-Wdelete-non-virtual-dtor]
  309 |                         if(_removePtrs) delete q->ptr();
      |                                         ^~~~~~~~~~~~~~~
make[1]: *** [Makefile.dynamic:16: random.o] Error 1
```